### PR TITLE
Scenario Outline screenshots overwrite previous loops

### DIFF
--- a/src/Context/BehatFormatterContext.php
+++ b/src/Context/BehatFormatterContext.php
@@ -64,7 +64,7 @@ class BehatFormatterContext extends MinkContext implements SnippetAcceptingConte
             }
 
             //create filename string
-            $fileName = $currentSuite.".".basename($scope->getFeature()->getFile()).'.'.$scope->getStep()->getLine().'.png';
+            $fileName = $currentSuite.".".basename($scope->getFeature()->getFile()).'.'.$this->currentScenario->getLine().'.'.$scope->getStep()->getLine().'.png';
             $fileName = str_replace('.feature', '', $fileName);
 
             /*


### PR DESCRIPTION
Screenshots in Scenario Outlines overwrite screenshots from prior iteration(s) of that scenario outline.

I'm working to add a unique identifier for each Scenario Outline in the filename of the screenshot. The simplest solution appeared to be $this->currentScenario->getLine(), however the result of that function is different in BehatFormatterContext.php (returns current example line) compared to BehatFormatter.php (return scenario definition line).