### PR TITLE
support multi-lines step arguments

### DIFF
--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -295,7 +295,7 @@
                                                                     {% endif %}
                                                                     {% if printStepArgs is not null %}
                                                                        {% for argument in step.arguments %}
-                                                                          <p style="padding-left:0.5em; overflow-x:scroll; white-space:nowrap; font-family:monospace">{{ argument | nl2br }}</p>
+                                                                          <pre style="padding-left:0.5em; overflow-x:scroll; font-family:monospace">{{ argument }}</pre>
                                                                        {% endfor %}
                                                                     {% endif %}
                                                                     {% if step.exception is not null %}


### PR DESCRIPTION
Support multiline step arguments, for example:

<img width="1184" alt="screen shot 2017-03-26 at 00 13 06" src="https://cloud.githubusercontent.com/assets/181350/24324048/fdff8f82-11b9-11e7-95de-29730abbd857.png">
