### PR TITLE
fix: Notice: A non well formed numeric value

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -63,7 +63,7 @@ class FeatureContext implements Context
     public function prepareTestFolders()
     {
         $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat' . DIRECTORY_SEPARATOR .
-            md5(microtime() * rand(0, 10000));
+            md5(microtime(true) * rand(0, 10000));
 
         mkdir($dir . '/features/bootstrap/i18n', 0777, true);
         mkdir($dir . '/junit');


### PR DESCRIPTION
… encountered in features/bootstrap/FeatureContext.php line 66

On PHP 7.4

microtime()'s output was a string, and we multipied it, hence the notice.

Not 100% sure this fix works on earlier versions of PHP.
Online doc https://www.php.net/manual/en/function.microtime.php
suggests that it should work.

See #12 