### PR TITLE
Changed the parameter type of BehatFormatter::onAfterExercise():

### DIFF
--- a/src/Formatter/BehatFormatter.php
+++ b/src/Formatter/BehatFormatter.php
@@ -541,9 +541,9 @@ class BehatFormatter implements Formatter {
     }
 
     /**
-     * @param AfterExerciseCompleted $event
+     * @param \Behat\Testwork\EventDispatcher\Event\AfterExerciseCompleted|\Behat\Testwork\EventDispatcher\Event\AfterExerciseAborted $event
      */
-    public function onAfterExercise(AfterExerciseCompleted $event)
+    public function onAfterExercise(ExerciseCompleted $event)
     {
 
         $this->timer->stop();


### PR DESCRIPTION
When canceling a behat test via `Ctrl+C`, this method will receive an `AfterExerciseAborted` object when it's expecting only a `AfterExerciseCompleted` object.

This will result in an error with the following message: `TypeError: Argument 1 passed to elkan\BehatFormatter\Formatter\BehatFormatter::onAfterExercise() must be an instance of Behat\Testwork\EventDispatcher\Event\AfterExerciseCompleted, instance of Behat\Testwork\EventDispatcher\Event\AfterExerciseAborted given`

Since this method can receive both AfterExerciseAborted / AfterExerciseCompleted objects the parameter type docs was changed to both, and the strict parameter type was changed to the common parent of both classes: `ExerciseCompleted`